### PR TITLE
Doc link updates 

### DIFF
--- a/ws/doc/o_dev_objc.md
+++ b/ws/doc/o_dev_objc.md
@@ -31,7 +31,7 @@ WebSocket and Objective-C
 
 KAAZING Gateway provides support for the HTML5 Communication protocol libraries in Objective-C. Using the Objective-C Client API, you can enable the HTML5 WebSocket protocols in new or existing Objective-C applications. For example, you can create an Objective-C client to get streaming financial or news data from a back-end server using WebSocket. The following figure shows a high-level overview of the architecture:
 
-![](../images/f-html5-objc-client-web.png)
+![](images/f-html5-objc-client-web.png)
 
 **Figure: Enable Communication Between Your iOS Client and a Back-end Server over WebSocket**
 

--- a/ws/doc/p_dev_objc_client.md
+++ b/ws/doc/p_dev_objc_client.md
@@ -65,7 +65,7 @@ The examples in this section will demonstrate how to open and close a WebSocket 
 
 The following example demonstrates how to open and close a connection. A best practice when connecting is to use a `try...catch` block. Note that the WebSocket connection is also closed when the app enters the background and is set to reconnect when the app enters the foreground.
 
-``` m
+``` objective-c
 - (void) createAndEstablishWebSocketConnection:(NSString *)location {
     @try {
         [self log:@&quot;CONNECTING&quot;];

--- a/ws/doc/p_dev_objc_client.md
+++ b/ws/doc/p_dev_objc_client.md
@@ -690,7 +690,7 @@ For information about the KAAZING Gateway Objective-C Client API, see [Objective
         ```
 
 24. Ensure that the `KGViewController` implementation class ends with its `@end` statement.
-25. Start the Gateway as described in **How do I start and stop the Gateway?** in [Setting Up KAAZING Gateway](../about/setup-guide.md).
+25. Start the Gateway as described in **How do I start and stop the Gateway?** in [Setting Up KAAZING Gateway](https://github.com/kaazing/gateway/blob/develop/doc/about/setup-guide.md).
 26. Build and run the client in the iPhone Simulator.
     1.  In the **Scheme** menu, select **iPhone 5.1 Simulator** or **iPhone 6.1 Simulator**.
     2.  Click **Run**.

--- a/ws/doc/p_dev_objc_secure.md
+++ b/ws/doc/p_dev_objc_secure.md
@@ -21,7 +21,7 @@ Creating a Basic Challenge Handler
 
 A challenge handler is a constructor used in a client to respond to authentication challenges from the Gateway when the client attempts to access a protected resource. Each of the resources protected by the Gateway can be configured with a different authentication scheme (for example, Basic, Application Basic, Negotiate, Application Negotiate, or Application Token), and your client requires a challenge handler for each of the schemes that it will encounter or a single challenge handler that will respond to all challenges.
 
-For information about each authentication scheme type, see [Configure the HTTP Challenge Scheme](../security/p_aaa_config_authscheme.md).
+For information about each authentication scheme type, see [Configure the HTTP Challenge Scheme](https://github.com/kaazing/gateway/blob/develop/doc/security/p_authentication_config_http_challenge_scheme.md).
 
 Clients with a single challenge handling strategy for all 401 challenges can simply set a specific challenge handler as the default using `KGBasicChallengeHandler`. The following is an example of how to implement a single challenge handler for all challenges:
 


### PR DESCRIPTION
This request contains changes to doc links within the Markdown files. Links are updated to direct to correct path, either by updating the link's filename or by replacing a link with the absolute URL (for cross-repo doc links). These errors originally occurred during Doc migration. Address "fix broken links" in [Deliver documentation to website upon release](https://github.com/kaazing/roadmap/issues/320).
